### PR TITLE
fix(pane-index): Use pane-base-index properly

### DIFF
--- a/src/load/tmux/mod.rs
+++ b/src/load/tmux/mod.rs
@@ -212,6 +212,6 @@ pub fn has_session(target: &str) -> ExitStatus {
 /// ```
 pub fn get_config() -> String {
     let output =
-        call(&["start-server", ";", "show-options", "-g"]).expect("couldn't get tmux options");
+        call(&["start-server", ";", "show-options", "-g", ";", "show-options", "-g", "-w"]).expect("couldn't get tmux options");
     String::from_utf8_lossy(&output.stdout).to_string()
 }


### PR DESCRIPTION
Something changed around TMUX 2.2 where base-pane-index is no longer
displayed under global options. Fetch the window based options as well.

Fixes: #31