### PR TITLE
Reduce Project Path & First Run Check code duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
 name = "common"
 version = "0.7.2-development"
 dependencies = [
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -228,7 +229,6 @@ name = "new"
 version = "0.7.2-development"
 dependencies = [
  "common 0.7.2-development",
- "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -403,7 +403,6 @@ name = "snapshot"
 version = "0.7.2-development"
 dependencies = [
  "common 0.7.2-development",
- "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ name = "common"
 version = "0.7.2-development"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ members = [
 
 [dependencies]
 common   = { path = "./common" }
+docopt   = "0.7"
 edit     = { path = "./edit" }
 load     = { path = "./load" }
 new      = { path = "./new" }
 snapshot = { path = "./snapshot" }
-docopt   = "0.7"
 
 [dev-dependencies]
 dirs      = "1.0.5"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,4 +9,5 @@ doctest = false
 
 [dependencies]
 dirs            = "1.0.5"
+rand            = "0.3.15"
 rustc-serialize = "0.3"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,4 +8,5 @@ publish = false
 doctest = false
 
 [dependencies]
+dirs            = "1.0.5"
 rustc-serialize = "0.3"

--- a/common/src/args.rs
+++ b/common/src/args.rs
@@ -1,4 +1,5 @@
 //! The struct managing cli args
+use rand::random;
 
 /// The args struct for taking arguments passed in from the command line
 /// and making it easier to pass around.
@@ -25,4 +26,23 @@ pub struct Args {
     pub cmd_edit: bool,
     pub cmd_new: bool,
     pub cmd_snapshot: bool,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        let name = format!("{}", random::<u16>());
+
+        Args {
+            arg_project: name,
+            cmd_edit: false,
+            cmd_new: true,
+            cmd_snapshot: false,
+            flag_d: true,
+            flag_debug: false,
+            flag_f: false,
+            flag_p: None,
+            flag_t: None,
+            flag_v: false,
+        }
+    }
 }

--- a/common/src/first_run.rs
+++ b/common/src/first_run.rs
@@ -1,13 +1,12 @@
-//! Muxednew. A Muxed project Template Generator
 use std::fs::create_dir;
 use std::path::Path;
 
 /// Used just to check for the existence of the default path. Prints out
 /// useful messages as to what's happening.
-pub fn check_first_run(muxed_dir: &str) -> Result<(), String> {
-    if !Path::new(muxed_dir).exists() {
-        create_dir(muxed_dir).map_err(|e| format!("We noticed the configuration directory: `{}` didn't exist so we tried to create it, but something went wrong: {}", muxed_dir, e))?;
-        println!("Looks like this is your first time here. Muxed could't find the configuration directory: `{}`", muxed_dir);
+pub fn check_first_run(muxed_dir: &Path) -> Result<(), String> {
+    if !muxed_dir.exists() {
+        create_dir(muxed_dir).map_err(|e| format!("We noticed the configuration directory: `{}` didn't exist so we tried to create it, but something went wrong: {}", muxed_dir.display(), e))?;
+        println!("Looks like this is your first time here. Muxed could't find the configuration directory: `{}`", muxed_dir.display());
         println!("Creating that now \u{1F44C}\n")
     };
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate dirs;
+extern crate rand;
 
 pub mod args;
 pub mod first_run;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,2 +1,5 @@
+extern crate dirs;
+
 pub mod args;
 pub mod first_run;
+pub mod project_paths;

--- a/common/src/project_paths.rs
+++ b/common/src/project_paths.rs
@@ -69,61 +69,28 @@ mod test {
 
     #[test]
     fn expects_tmp_as_default_homedir() {
-        let args = Args {
-            arg_project: "projectname".to_string(),
-            cmd_edit: false,
-            cmd_new: false,
-            cmd_snapshot: false,
-            flag_d: false,
-            flag_debug: false,
-            flag_dryrun: false,
-            flag_f: false,
-            flag_p: None,
-            flag_t: None,
-            flag_v: false,
-        };
-
+        let args: Args = Default::default();
         let project_paths = project_paths(&args);
+
         assert_eq!(project_paths.home_directory, PathBuf::from("/tmp"))
     }
 
     #[test]
     fn expects_muxed_as_default_project_dir() {
-        let args = Args {
-            arg_project: "projectname".to_string(),
-            cmd_edit: false,
-            cmd_new: false,
-            cmd_snapshot: false,
-            flag_d: false,
-            flag_debug: false,
-            flag_dryrun: false,
-            flag_f: false,
-            flag_p: None,
-            flag_t: None,
-            flag_v: false,
-        };
-
+        let args: Args = Default::default();
         let project_paths = project_paths(&args);
+
         assert_eq!(project_paths.project_directory, PathBuf::from("/tmp/.muxed"))
     }
 
     #[test]
     fn expects_spacey_as_homedir() {
         let args = Args {
-            arg_project: "projectname".to_string(),
-            cmd_edit: false,
-            cmd_new: false,
-            cmd_snapshot: false,
-            flag_d: false,
-            flag_debug: false,
-            flag_dryrun: false,
-            flag_f: false,
             flag_p: Some("/spacey".to_string()),
-            flag_t: None,
-            flag_v: false,
+            ..Default::default()
         };
-
         let project_paths = project_paths(&args);
+
         assert_eq!(project_paths.project_directory, PathBuf::from("/spacey"))
     }
 
@@ -131,19 +98,10 @@ mod test {
     fn expects_projectname_as_yml_file() {
         let args = Args {
             arg_project: "projectname".to_string(),
-            cmd_edit: false,
-            cmd_new: false,
-            cmd_snapshot: false,
-            flag_d: false,
-            flag_debug: false,
-            flag_dryrun: false,
-            flag_f: false,
-            flag_p: None,
-            flag_t: None,
-            flag_v: false,
+            ..Default::default()
         };
-
         let project_paths = project_paths(&args);
+
         assert_eq!(project_paths.project_file, PathBuf::from("/tmp/.muxed/projectname.yml"))
     }
 }

--- a/common/src/project_paths.rs
+++ b/common/src/project_paths.rs
@@ -21,7 +21,6 @@ impl ProjectPaths {
         }
     }
 
-    #[cfg(test)]
     pub fn from_strs(home_directory: &str, project_directory: &str, project_file: &str) -> ProjectPaths {
         let home_directory = PathBuf::from(home_directory);
         let project_directory = home_directory.join(project_directory);
@@ -66,7 +65,85 @@ fn homedir() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod test {
-    #[test]
-    fn 
+    use super::*;
 
+    #[test]
+    fn expects_tmp_as_default_homedir() {
+        let args = Args {
+            arg_project: "projectname".to_string(),
+            cmd_edit: false,
+            cmd_new: false,
+            cmd_snapshot: false,
+            flag_d: false,
+            flag_debug: false,
+            flag_dryrun: false,
+            flag_f: false,
+            flag_p: None,
+            flag_t: None,
+            flag_v: false,
+        };
+
+        let project_paths = project_paths(&args);
+        assert_eq!(project_paths.home_directory, PathBuf::from("/tmp"))
+    }
+
+    #[test]
+    fn expects_muxed_as_default_project_dir() {
+        let args = Args {
+            arg_project: "projectname".to_string(),
+            cmd_edit: false,
+            cmd_new: false,
+            cmd_snapshot: false,
+            flag_d: false,
+            flag_debug: false,
+            flag_dryrun: false,
+            flag_f: false,
+            flag_p: None,
+            flag_t: None,
+            flag_v: false,
+        };
+
+        let project_paths = project_paths(&args);
+        assert_eq!(project_paths.project_directory, PathBuf::from("/tmp/.muxed"))
+    }
+
+    #[test]
+    fn expects_spacey_as_homedir() {
+        let args = Args {
+            arg_project: "projectname".to_string(),
+            cmd_edit: false,
+            cmd_new: false,
+            cmd_snapshot: false,
+            flag_d: false,
+            flag_debug: false,
+            flag_dryrun: false,
+            flag_f: false,
+            flag_p: Some("/spacey".to_string()),
+            flag_t: None,
+            flag_v: false,
+        };
+
+        let project_paths = project_paths(&args);
+        assert_eq!(project_paths.project_directory, PathBuf::from("/spacey"))
+    }
+
+    #[test]
+    fn expects_projectname_as_yml_file() {
+        let args = Args {
+            arg_project: "projectname".to_string(),
+            cmd_edit: false,
+            cmd_new: false,
+            cmd_snapshot: false,
+            flag_d: false,
+            flag_debug: false,
+            flag_dryrun: false,
+            flag_f: false,
+            flag_p: None,
+            flag_t: None,
+            flag_v: false,
+        };
+
+        let project_paths = project_paths(&args);
+        assert_eq!(project_paths.project_file, PathBuf::from("/tmp/.muxed/projectname.yml"))
+    }
 }

--- a/common/src/project_paths.rs
+++ b/common/src/project_paths.rs
@@ -1,0 +1,72 @@
+use args::Args;
+#[cfg(not(test))]
+use dirs::home_dir;
+use std::path::PathBuf;
+
+pub static MUXED_FOLDER: &str = ".muxed";
+static CONFIG_EXTENSION: &str = "yml";
+
+pub struct ProjectPaths {
+    pub home_directory: PathBuf,
+    pub project_directory: PathBuf,
+    pub project_file: PathBuf,
+}
+
+impl ProjectPaths {
+    pub fn new(home_directory: PathBuf, project_directory: PathBuf, project_file: PathBuf) -> ProjectPaths {
+        ProjectPaths {
+            home_directory,
+            project_directory,
+            project_file,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn from_strs(home_directory: &str, project_directory: &str, project_file: &str) -> ProjectPaths {
+        let home_directory = PathBuf::from(home_directory);
+        let project_directory = home_directory.join(project_directory);
+        let project_file = project_directory.join(project_file).with_extension(CONFIG_EXTENSION);
+
+        ProjectPaths {
+            home_directory,
+            project_directory,
+            project_file,
+        }
+    }
+}
+
+/// A common method for returning the project directory and filepath. The method
+/// will check for a passed argument set with -p but if it does not exist will
+/// map the path for the .muxed directory in the users home directory and return
+/// that as the default.
+pub fn project_paths(args: &Args) -> ProjectPaths {
+    let homedir = homedir().expect("We couldn't find your home directory.");
+    let default_dir = homedir.join(MUXED_FOLDER);
+    let project_directory = args.flag_p.as_ref().map_or(default_dir, |p| PathBuf::from(p));
+
+    let project_filename = PathBuf::from(&args.arg_project).with_extension(CONFIG_EXTENSION);
+    let project_fullpath = project_directory.join(project_filename);
+
+    ProjectPaths::new(homedir, project_directory, project_fullpath)
+}
+
+/// A Thin wrapper around the home_dir crate. This is so we can swap the default
+/// dir out during testing.
+#[cfg(not(test))]
+fn homedir() -> Option<PathBuf> {
+    home_dir()
+}
+
+/// Return the temp dir as the users home dir during testing.
+#[cfg(test)]
+fn homedir() -> Option<PathBuf> {
+    Some(PathBuf::from("/tmp"))
+}
+
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn 
+
+}

--- a/edit/Cargo.toml
+++ b/edit/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 common = { path = "../common" }
 dirs   = "1.0.5"
-libc      = "0.2.21"
+libc   = "0.2.21"
 
 [dev-dependencies]
 rand   = "0.3.15"

--- a/edit/src/lib.rs
+++ b/edit/src/lib.rs
@@ -1,55 +1,22 @@
 //! Muxednew. A Muxed project Template Generator
 extern crate common;
-extern crate dirs;
 extern crate libc;
-#[cfg(test)]
-extern crate rand;
 
 use common::args::Args;
+use common::project_paths::project_paths;
 
-#[cfg(not(test))]
-use dirs::home_dir;
 use libc::system;
-#[cfg(test)]
-use rand::random;
 use std::ffi::CString;
-#[cfg(test)]
-use std::fs;
 use std::io;
-use std::path::PathBuf;
-
-static MUXED_FOLDER: &str = "muxed";
 
 pub fn exec(args: Args) -> Result<(), io::Error> {
-    let home = homedir().expect("Can't find home dir");
-    let default_dir = format!("{}/.{}", home.display(), MUXED_FOLDER);
-    let project_name = format!("{}.yml", &args.arg_project);
-    let muxed_dir = match args.flag_p {
-        Some(ref x) => x.as_str(),
-        _ => default_dir.as_str(),
-    };
-
-    let command = format!("{} {}/{}", "$EDITOR", muxed_dir, project_name);
-    let system_call = CString::new(command).unwrap();
+    let project_paths = project_paths(&args);
+    let command = format!("{} {}", "$EDITOR", project_paths.project_file.display());
+    let system_call = CString::new(command).expect("Couldn't create the editor open command");
 
     unsafe {
         system(system_call.as_ptr());
     };
 
     Ok(())
-}
-
-/// Return the users homedir as a string.
-#[cfg(not(test))]
-fn homedir() -> Result<PathBuf, String> {
-    match home_dir() {
-        Some(dir) => Ok(dir),
-        None => Err(String::from("We couldn't find your home directory.")),
-    }
-}
-
-/// Return the temp dir as the users home dir during testing.
-#[cfg(test)]
-fn homedir() -> Result<PathBuf, String> {
-    Ok(PathBuf::from("/tmp"))
 }

--- a/load/Cargo.toml
+++ b/load/Cargo.toml
@@ -14,9 +14,9 @@ libc      = "0.2.21"
 yaml-rust = { version = "0.3.2", default-features = false }
 
 [dev-dependencies]
-snapshot 	= { path = "../snapshot" }
 dirs      = "1.0.5"
 libc      = "0.2.21"
 rand      = "0.3.15"
 regex     = "0.2.1"
+snapshot  = { path = "../snapshot" }
 yaml-rust = { version = "0.3.2", default-features = false }

--- a/load/src/lib.rs
+++ b/load/src/lib.rs
@@ -12,26 +12,15 @@ pub mod tmux;
 
 use args::Args;
 use command::Commands;
+use common::project_paths::project_paths;
 use common::{args, first_run};
 use project::parser;
 use tmux::config::Config;
 
-#[cfg(not(test))]
-use dirs::home_dir;
-use std::path::PathBuf;
-
-static MUXED_FOLDER: &str = "muxed";
-
 pub fn exec(args: Args) -> Result<(), String> {
-    // FIXME: If -p flag isn't set there's no default?
-    let home = homedir().expect("Can't find home dir");
-    let default_dir = format!("{}/.{}", home.display(), MUXED_FOLDER);
-    let muxed_dir = match args.flag_p {
-        Some(ref x) => Some(x.as_str()),
-        _ => Some(default_dir.as_str()),
-    };
+    let project_paths = project_paths(&args);
 
-    let yaml = project::read(&args.arg_project, &muxed_dir).unwrap();
+    let yaml = project::read(&args.arg_project, &project_paths).unwrap();
     let project_name = &yaml[0]["name"]
         .as_str()
         .unwrap_or(&args.arg_project)
@@ -62,19 +51,4 @@ pub fn exec(args: Args) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-/// Return the users homedir as a string.
-#[cfg(not(test))]
-fn homedir() -> Result<PathBuf, String> {
-    match home_dir() {
-        Some(dir) => Ok(dir),
-        None => Err(String::from("We couldn't find your home directory.")),
-    }
-}
-
-/// Return the temp dir as the users home dir during testing.
-#[cfg(test)]
-fn homedir() -> Result<PathBuf, String> {
-    Ok(PathBuf::from("/tmp"))
 }

--- a/load/tests/helpers/mod.rs
+++ b/load/tests/helpers/mod.rs
@@ -65,16 +65,9 @@ pub fn test_with_contents(contents: &[u8]) -> snapshot::tmux::session::Session {
 
 fn open_muxed(project: &str, project_root: &Path) -> Result<(), String> {
     let args = Args {
-        flag_debug: false,
-        flag_d: true,
-        flag_v: false,
-        flag_f: false,
-        flag_p: Some(format!("{}", project_root.display())),
-        flag_t: None,
         arg_project: project.to_string(),
-        cmd_edit: false,
-        cmd_new: false,
-        cmd_snapshot: false,
+        flag_p: Some(format!("{}", project_root.display())),
+        ..Default::default()
     };
 
     load::exec(args)

--- a/new/Cargo.toml
+++ b/new/Cargo.toml
@@ -9,7 +9,6 @@ doctest = false
 
 [dependencies]
 common = { path = "../common" }
-dirs   = "1.0.5"
 
 [dev-dependencies]
 rand   = "0.3.15"

--- a/new/tests/new.rs
+++ b/new/tests/new.rs
@@ -15,16 +15,10 @@ mod test {
 
         pub fn new(project: &str, project_root: &PathBuf) -> Result<(), String> {
             let args = Args {
-                flag_debug: false,
-                flag_d: true,
-                flag_v: false,
-                flag_f: false,
                 flag_p: Some(format!("{}", project_root.display())),
-                flag_t: None,
                 arg_project: project.to_string(),
-                cmd_edit: false,
                 cmd_new: true,
-                cmd_snapshot: false,
+                ..Default::default()
             };
 
             new::exec(args)

--- a/snapshot/Cargo.toml
+++ b/snapshot/Cargo.toml
@@ -9,7 +9,6 @@ doctest = false
 
 [dependencies]
 common       = { path = "../common" }
-dirs         = "1.0.5"
 regex        = "0.2.1"
 serde        = "0.8.18"
 serde_derive = "0.8.18"


### PR DESCRIPTION
From the days when `new`, `load`, and `snapshot` were in separate repositories and before `common` existed code for getting the default directory and project path, as well as checking first run was duplicated in each crate.

Finally refactor the duplication out. Additionally stop using string formed arguments and utilize real structs. Uses `std::default` to make struct creation simpler and less noisy in tests.