### PR TITLE
Force overwrite new file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ name = "snapshot"
 version = "0.7.2-development"
 dependencies = [
  "common 0.7.2-development",
+ "new 0.7.2-development",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/muxed-completion.bash
+++ b/muxed-completion.bash
@@ -1,0 +1,14 @@
+#/usr/bin/env bash
+_muxed_completions()
+{
+  if [ "$COMP_CWORD" -eq 1 ]; then
+    local commands="$(compgen -W "new edit snapshot" "${COMP_WORDS[1]}")"
+    local projects="$(compgen -W "$(echo $(ls ~/.muxed/))" "${COMP_WORDS[1]}")"
+    COMPREPLY=( $commands $projects )
+  elif [ "$COMP_CWORD" -eq 2 ]; then
+    local projects="$(compgen -W "$(echo $(ls ~/.muxed/))" "${COMP_WORDS[2]}")"
+    COMPREPLY=( $projects )
+  fi
+}
+
+complete -F _muxed_completions muxed

--- a/new/src/lib.rs
+++ b/new/src/lib.rs
@@ -33,7 +33,8 @@ pub fn exec(args: Args) -> Result<(), String> {
     check_first_run(&project_paths.project_directory)?;
 
     let template = modified_template(TEMPLATE, &project_paths.project_file);
-    write_template(&template, &project_paths.project_file).unwrap();
+    write_template(&template, &project_paths.project_file, args.flag_f)?;
+
     println!(
         "\u{270C} The template file {} has been written to {}\nHappy tmuxing!",
         &project_paths.project_file.display(),
@@ -46,15 +47,20 @@ fn modified_template(template: &str, file: &PathBuf) -> String {
     template.replace("{file}", file.to_str().unwrap())
 }
 
-fn write_template(template: &str, path: &PathBuf) -> Result<(), String> {
-    let path_str = path.to_str().unwrap();
+fn write_template<S>(template: S, path: &PathBuf, force: bool) -> Result<(), String>
+where
+    S: Into<String>,
+{
+    let path_str = path.to_str().expect("Path could not be opened");
     let mut file = OpenOptions::new()
         .write(true)
-        .create_new(true)
+        .truncate(force)
+        .create(force)
+        .create_new(!force)
         .open(path)
         .map_err(|e| format!("Could not create the file {}. Error: {}", &path_str, e))?;
 
-    file.write_all(template.as_bytes()).map_err(|e| {
+    file.write_all(template.into().as_bytes()).map_err(|e| {
         format!(
             "Could not write contents of template to the file {}. Error {}",
             &path_str, e
@@ -72,7 +78,6 @@ mod test {
     use common::rand_names;
     use std::fs::File;
     use std::fs;
-    use std::io::Read;
     use super::*;
 
     #[test]
@@ -118,7 +123,7 @@ mod test {
     #[test]
     fn expect_ok_result_when_path_exists() {
         let path = rand_names::project_file_with_dir("/tmp");
-        let result = write_template(&"test template".to_string(), &path);
+        let result = write_template(&"test template".to_string(), &path, false);
         let _ = fs::remove_file(path);
         println!("{:?}", result);
         assert!(result.is_ok());
@@ -127,14 +132,14 @@ mod test {
     #[test]
     fn expect_err_result_when_path_does_not_exist() {
         let path = rand_names::project_file_path();
-        let result = write_template(&"test template".to_string(), &path);
+        let result = write_template(&"test template".to_string(), &path, false);
         assert!(result.is_err());
     }
 
     #[test]
     fn expect_new_file_to_exist() {
         let path = rand_names::project_file_with_dir("/tmp");
-        let _ = write_template(&"test template".to_string(), &path);
+        let _ = write_template(&"test template".to_string(), &path, false);
         let result = &path.exists();
         let _ = fs::remove_file(&path);
         assert!(result);
@@ -143,7 +148,7 @@ mod test {
     #[test]
     fn expect_new_file_not_to_exist() {
         let path = rand_names::project_file_path();
-        let _ = write_template(&"test template".to_string(), &path);
+        let _ = write_template(&"test template".to_string(), &path, false);
         assert!(!path.exists());
     }
 
@@ -156,14 +161,28 @@ mod test {
         let _ = buffer.sync_all();
 
         // Attempt to create the same named file with new content
-        let _ = write_template(&"new_content".to_string(), &path);
+        let _ = write_template(&"new_content".to_string(), &path, false);
 
-        // Read the file content
-        let mut f = File::open(&path).unwrap();
-        let mut s = String::new();
-        let _ = f.read_to_string(&mut s);
+        let content = fs::read_to_string(&path).unwrap();
 
-        assert_eq!(s, "original content");
+        assert_eq!(content, "original content");
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn expect_truncation_or_overwrite() {
+        // Write a file with content
+        let path = rand_names::project_file_with_dir("/tmp");
+        let mut buffer = File::create(&path).unwrap();
+        let _ = buffer.write(b"original content");
+        let _ = buffer.sync_all();
+
+        // Attempt to create the same named file with new content
+        let _ = write_template(&"new content".to_string(), &path, true);
+
+        let content = fs::read_to_string(&path).unwrap();
+
+        assert_eq!(content, "new content");
         let _ = fs::remove_file(&path);
     }
 
@@ -173,7 +192,7 @@ mod test {
         let mut buffer = File::create(&path).unwrap();
         let _ = buffer.write(b"original content");
         let _ = buffer.sync_all();
-        let result = write_template(&"new_content".to_string(), &path);
+        let result = write_template(&"new content".to_string(), &path, false);
 
         assert!(result.is_err());
         let _ = fs::remove_file(&path);

--- a/new/src/lib.rs
+++ b/new/src/lib.rs
@@ -44,10 +44,10 @@ pub fn exec(args: Args) -> Result<(), String> {
 }
 
 fn modified_template(template: &str, file: &PathBuf) -> String {
-    template.replace("{file}", file.to_str().unwrap())
+    template.replace("{file}", file.to_str().expect("Couldn't convert the {:?} path into a String to write into the new file"))
 }
 
-fn write_template<S>(template: S, path: &PathBuf, force: bool) -> Result<(), String>
+pub fn write_template<S>(template: S, path: &PathBuf, force: bool) -> Result<(), String>
 where
     S: Into<String>,
 {

--- a/new/tests/new.rs
+++ b/new/tests/new.rs
@@ -12,17 +12,6 @@ mod test {
         use std::fs;
         use std::path::Path;
 
-        pub fn new(project_path: &Path) -> Result<(), String> {
-            let args = Args {
-                flag_p: Some(project_path.parent().unwrap().display().to_string()),
-                arg_project: project_path.file_name().unwrap().to_str().unwrap().to_string(),
-                cmd_new: true,
-                ..Default::default()
-            };
-
-            new::exec(args)
-        }
-
         fn cleanup(config_path: &Path) {
             let _ = fs::remove_file(config_path);
             let _ = fs::remove_dir(config_path.parent().unwrap());
@@ -32,8 +21,57 @@ mod test {
         fn creates_new_file() {
             let project_path = rand_names::project_file_path();
 
-            assert!(new(&project_path).is_ok());
+            let args = Args {
+                arg_project: project_path.file_name().unwrap().to_str().unwrap().to_string(),
+                cmd_new: true,
+                flag_p: Some(project_path.parent().unwrap().display().to_string()),
+                ..Default::default()
+            };
+
+            assert!(new::exec(args).is_ok());
             assert!(&project_path.exists());
+
+            cleanup(&project_path);
+        }
+
+        #[test]
+        fn overwrites_existing_file() {
+            let project_path = rand_names::project_file_path();
+            let _ = fs::create_dir(project_path.parent().as_ref().unwrap());
+            let _ = fs::File::create(&project_path);
+
+            let args = Args {
+                arg_project: project_path.file_name().unwrap().to_str().unwrap().to_string(),
+                cmd_new: true,
+                flag_f: true,
+                flag_p: Some(project_path.parent().unwrap().display().to_string()),
+                ..Default::default()
+            };
+
+            assert!(new::exec(args).is_ok());
+
+            let contents = fs::read_to_string(&project_path).unwrap();
+
+            let name = format!("# {}", project_path.display());
+            assert!(contents.contains(&name));
+
+            cleanup(&project_path);
+        }
+
+        #[test]
+        fn fails_to_write_over_existing_file() {
+            let project_path = rand_names::project_file_path();
+            let _ = fs::create_dir(project_path.parent().as_ref().unwrap());
+            let _ = fs::File::create(&project_path);
+
+            let args = Args {
+                arg_project: project_path.file_name().unwrap().to_str().unwrap().to_string(),
+                cmd_new: true,
+                flag_p: Some(project_path.parent().unwrap().display().to_string()),
+                ..Default::default()
+            };
+
+            assert!(new::exec(args).is_err());
 
             cleanup(&project_path);
         }

--- a/snapshot/Cargo.toml
+++ b/snapshot/Cargo.toml
@@ -9,6 +9,7 @@ doctest = false
 
 [dependencies]
 common       = { path = "../common" }
+new          = { path = "../new" }
 regex        = "1.3.1"
 serde        = { version = "1.0.103", features = ["derive"] }
 serde_yaml   = "0.8"

--- a/snapshot/src/lib.rs
+++ b/snapshot/src/lib.rs
@@ -1,5 +1,6 @@
 //! Muxedsnapshot. A tmux session cloner for Muxed.
 extern crate common;
+extern crate new;
 extern crate regex;
 extern crate serde;
 extern crate serde_yaml;
@@ -10,9 +11,7 @@ pub mod tmux;
 use common::args::Args;
 use common::first_run::check_first_run;
 use common::project_paths::project_paths;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::PathBuf;
+use new::write_template as write_config;
 
 /// The main execution method.
 /// Accepts two arguments. -n for the name of the project file and -t to target
@@ -42,33 +41,6 @@ pub fn exec(args: Args) -> Result<(), String> {
 
     write_config(s, &project_paths.project_file, args.flag_f).unwrap();
     println!("We made a snapshot of your session! \u{1F60A}");
-    Ok(())
-}
-
-/// Write the new file
-fn write_config<S>(template: S, path: &PathBuf, force: bool) -> Result<(), String>
-where
-    S: Into<String>,
-{
-    let path_str = path.to_str().expect("Path could not be opened");
-    let mut file = OpenOptions::new()
-        .write(true)
-        .truncate(force)
-        .create(force)
-        .create_new(!force)
-        .open(path)
-        .map_err(|e| format!("Could not create the file {}. Error: {}", &path_str, e))?;
-
-    file.write_all(template.into().as_bytes()).map_err(|e| {
-        format!(
-            "Could not write contents of template to the file {}. Error {}",
-            &path_str, e
-        )
-    })?;
-
-    file.sync_all()
-        .map_err(|e| format!("Could not sync OS data post-write. Error: {}", e))?;
-
     Ok(())
 }
 


### PR DESCRIPTION
This is a fix for #44.

Included is also a refactoring to utilize the same new template code between snapshot and new.