### PR TITLE
imp: CLI Usage Improvments

### DIFF
--- a/common/src/args.rs
+++ b/common/src/args.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 /// `cmd_edit` if `true` run edit command
 /// `cmd_new` if `true` run new command
 /// `cmd_snapshot` if `true` run snapshot command
+/// `cmd_load` if `true` run load command (This is also the default command)
 ///
 #[derive(Debug, Deserialize)]
 pub struct Args {
@@ -27,6 +28,7 @@ pub struct Args {
     pub cmd_edit: bool,
     pub cmd_new: bool,
     pub cmd_snapshot: bool,
+    pub cmd_load: bool,
 }
 
 impl Default for Args {
@@ -38,6 +40,7 @@ impl Default for Args {
             cmd_edit: false,
             cmd_new: true,
             cmd_snapshot: false,
+            cmd_load: false,
             flag_d: true,
             flag_debug: false,
             flag_f: false,

--- a/common/src/args.rs
+++ b/common/src/args.rs
@@ -11,9 +11,9 @@ use serde::Deserialize;
 /// `flag_t` the session to read from
 /// `flag_debug` run inline print statements for debugging
 /// `arg_project` the project file to read
-/// `cmd_edit`
-/// `cmd_new` literally nothing
-/// `cmd_snapshot` not sure why I have these
+/// `cmd_edit` if `true` run edit command
+/// `cmd_new` if `true` run new command
+/// `cmd_snapshot` if `true` run snapshot command
 ///
 #[derive(Debug, Deserialize)]
 pub struct Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ macro_rules! try_or_err (
     })
 );
 
-static DISALLOWED_PROJECT_NAMES: [&str; 3] = ["new", "edit", "load"];
+static DISALLOWED_PROJECT_NAMES: [&str; 2] = ["new", "edit"];
 
 static USAGE: &str = "
 Usage:
@@ -32,7 +32,6 @@ Usage:
     muxed edit [options] <project>
     muxed new [options] <project>
     muxed snapshot [options] <project>
-    muxed load [options] <project>
     muxed (-h | --help)
     muxed (-v | --version)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ pub fn main() {
         try_or_err!(snapshot::exec(args))
     } else if DISALLOWED_PROJECT_NAMES.contains(&args.arg_project.as_ref()) {
         println!(
-            "Tried to call sub-command {} without a project. Please specify a project name.",
+            "Tried to call sub-command '{}' without a project. Please specify a project name.",
             args.arg_project
         );
         exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ macro_rules! try_or_err (
     })
 );
 
-static DISALLOWED_SHORTHAND_PROJECT_NAMES: [&str; 2] = ["new", "edit"];
+static DISALLOWED_SHORTHAND_PROJECT_NAMES: [&str; 4] = ["new", "edit", "load", "snapshot"];
 
 static USAGE: &str = "
 Usage:

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ Subcommands:
     edit <project>                   Edit an existing project file
     new <project>                    To create a new project file
     snapshot -t <session> <project>  Capture a running session and create a config file for it
+    load                             Load the specified project, this is the default command
 ";
 
 /// The main execution method.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,11 +28,11 @@ static DISALLOWED_PROJECT_NAMES: [&str; 3] = ["new", "edit", "load"];
 
 static USAGE: &str = "
 Usage:
+    muxed [options] <project>
     muxed edit [options] <project>
     muxed new [options] <project>
     muxed snapshot [options] <project>
     muxed load [options] <project>
-    muxed [options] <project>
     muxed (-h | --help)
     muxed (-v | --version)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,8 +103,8 @@ pub fn main() {
                 args.arg_project
             );
             exit(1);
-        } else {
-            try_or_err!(load::exec(args))
         }
+
+        try_or_err!(load::exec(args))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,13 +90,13 @@ pub fn main() {
     };
 
     if args.cmd_new {
-        try_or_err!(new::exec(args))
+        try_or_err!(new::exec(args));
     } else if args.cmd_edit {
-        try_or_err!(edit::exec(args))
+        try_or_err!(edit::exec(args));
     } else if args.cmd_snapshot {
-        try_or_err!(snapshot::exec(args))
+        try_or_err!(snapshot::exec(args));
     } else if args.cmd_load {
-        try_or_err!(load::exec(args))
+        try_or_err!(load::exec(args));
     } else {
         if DISALLOWED_SHORTHAND_PROJECT_NAMES.contains(&args.arg_project.as_ref()) {
             println!(
@@ -106,6 +106,6 @@ pub fn main() {
             exit(1);
         }
 
-        try_or_err!(load::exec(args))
+        try_or_err!(load::exec(args));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,13 +96,15 @@ pub fn main() {
         try_or_err!(snapshot::exec(args))
     } else if args.cmd_load {
         try_or_err!(load::exec(args))
-    } else if DISALLOWED_SHORTHAND_PROJECT_NAMES.contains(&args.arg_project.as_ref()) {
-        println!(
-            "Tried to call sub-command '{}' without a project. Please specify a project name.",
-            args.arg_project
-        );
-        exit(1);
     } else {
-        try_or_err!(load::exec(args))
+        if DISALLOWED_SHORTHAND_PROJECT_NAMES.contains(&args.arg_project.as_ref()) {
+            println!(
+                "Tried to call sub-command '{}' without a project. Please specify a project name.",
+                args.arg_project
+            );
+            exit(1);
+        } else {
+            try_or_err!(load::exec(args))
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ macro_rules! try_or_err (
     })
 );
 
-static DISALLOWED_PROJECT_NAMES: [&str; 2] = ["new", "edit"];
+static DISALLOWED_SHORTHAND_PROJECT_NAMES: [&str; 2] = ["new", "edit"];
 
 static USAGE: &str = "
 Usage:
@@ -32,6 +32,7 @@ Usage:
     muxed edit [options] <project>
     muxed new [options] <project>
     muxed snapshot [options] <project>
+    muxed load [options] <project>
     muxed (-h | --help)
     muxed (-v | --version)
 
@@ -93,7 +94,9 @@ pub fn main() {
         try_or_err!(edit::exec(args))
     } else if args.cmd_snapshot {
         try_or_err!(snapshot::exec(args))
-    } else if DISALLOWED_PROJECT_NAMES.contains(&args.arg_project.as_ref()) {
+    } else if args.cmd_load {
+        try_or_err!(load::exec(args))
+    } else if DISALLOWED_SHORTHAND_PROJECT_NAMES.contains(&args.arg_project.as_ref()) {
         println!(
             "Tried to call sub-command '{}' without a project. Please specify a project name.",
             args.arg_project


### PR DESCRIPTION
First off thanks for the project! Been searching for a Tmuxinator replacement since dealing with the ruby versions has been a pain point in my setup recently and this project looks awesome!
Figured I would dip my toes in a bit here since I found the project!

# Fixes

This fixes the issue where `muxed new` and `muxed edit` would actually call the `load` command, and therefor create a new `yml` file, instead of reporting an error about the missing project name.

# Improvements

My fixes also meant that is was possible to edit and create a project named `new` or `edit` BUT it wouldn't have been possible to load such a project.
To fix this I added an explicit `load` command that can be used to differentiate it from calling `new` or `edit` without a project name.

This slight bit of added complexity is to make it possible to have a project named `new` or `edit`. If this isn't desired functionality the explicit `load` command could be removed.

Closes #46 and #45 

(Also let me know if you would like each commit to be re-based with a conventional commit style message!)