### PR TITLE
Add `list` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,13 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "list"
+version = "0.8.2-development"
+dependencies = [
+ "common 0.8.2-development",
+]
+
+[[package]]
 name = "load"
 version = "0.8.2-development"
 dependencies = [
@@ -230,6 +237,7 @@ dependencies = [
  "common 0.8.2-development",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "edit 0.8.2-development",
+ "list 0.8.2-development",
  "load 0.8.2-development",
  "new 0.8.2-development",
  "snapshot 0.8.2-development",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ edit     = { path = "./edit" }
 load     = { path = "./load" }
 new      = { path = "./new" }
 snapshot = { path = "./snapshot" }
+list = { path = "./list" }

--- a/common/src/args.rs
+++ b/common/src/args.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 /// `cmd_load` if `true` run load command (This is also the default command)
 /// `cmd_new` if `true` run new command
 /// `cmd_snapshot` if `true` run snapshot command
+/// `cmd_list` if `true` run list command
 ///
 #[derive(Debug, Deserialize)]
 pub struct Args {
@@ -29,6 +30,7 @@ pub struct Args {
     pub cmd_load: bool,
     pub cmd_new: bool,
     pub cmd_snapshot: bool,
+    pub cmd_list: bool,
 }
 
 impl Default for Args {
@@ -41,6 +43,7 @@ impl Default for Args {
             cmd_load: false,
             cmd_new: true,
             cmd_snapshot: false,
+            cmd_list: false,
             flag_d: true,
             flag_debug: false,
             flag_f: false,

--- a/common/src/args.rs
+++ b/common/src/args.rs
@@ -31,6 +31,7 @@ pub struct Args {
     pub cmd_new: bool,
     pub cmd_snapshot: bool,
     pub cmd_list: bool,
+    pub cmd_ls: bool,
 }
 
 impl Default for Args {
@@ -44,6 +45,7 @@ impl Default for Args {
             cmd_new: true,
             cmd_snapshot: false,
             cmd_list: false,
+            cmd_ls: false,
             flag_d: true,
             flag_debug: false,
             flag_f: false,

--- a/common/src/project_paths.rs
+++ b/common/src/project_paths.rs
@@ -3,7 +3,7 @@ use args::Args;
 use dirs::home_dir;
 use std::path::PathBuf;
 
-pub static CONFIG_EXTENSION: &str = "yml";
+pub const CONFIG_EXTENSION: &str = "yml";
 static MUXED_FOLDER: &str = ".muxed";
 
 pub struct ProjectPaths {
@@ -13,7 +13,11 @@ pub struct ProjectPaths {
 }
 
 impl ProjectPaths {
-    pub fn new(home_directory: PathBuf, project_directory: PathBuf, project_file: PathBuf) -> ProjectPaths {
+    pub fn new(
+        home_directory: PathBuf,
+        project_directory: PathBuf,
+        project_file: PathBuf,
+    ) -> ProjectPaths {
         ProjectPaths {
             home_directory,
             project_directory,
@@ -21,10 +25,16 @@ impl ProjectPaths {
         }
     }
 
-    pub fn from_strs(home_directory: &str, project_directory: &str, project_file: &str) -> ProjectPaths {
+    pub fn from_strs(
+        home_directory: &str,
+        project_directory: &str,
+        project_file: &str,
+    ) -> ProjectPaths {
         let home_directory = PathBuf::from(home_directory);
         let project_directory = home_directory.join(project_directory);
-        let project_file = project_directory.join(project_file).with_extension(CONFIG_EXTENSION);
+        let project_file = project_directory
+            .join(project_file)
+            .with_extension(CONFIG_EXTENSION);
 
         ProjectPaths {
             home_directory,
@@ -67,7 +77,10 @@ impl ProjectPaths {
 pub fn project_paths(args: &Args) -> ProjectPaths {
     let homedir = homedir().expect("We couldn't find your home directory.");
     let default_dir = homedir.join(MUXED_FOLDER);
-    let project_directory = args.flag_p.as_ref().map_or(default_dir, |p| PathBuf::from(p));
+    let project_directory = args
+        .flag_p
+        .as_ref()
+        .map_or(default_dir, |p| PathBuf::from(p));
 
     let project_filename = PathBuf::from(&args.arg_project).with_extension(CONFIG_EXTENSION);
     let project_fullpath = project_directory.join(project_filename);
@@ -105,7 +118,10 @@ mod test {
         let args: Args = Default::default();
         let project_paths = project_paths(&args);
 
-        assert_eq!(project_paths.project_directory, PathBuf::from("/tmp/.muxed"))
+        assert_eq!(
+            project_paths.project_directory,
+            PathBuf::from("/tmp/.muxed")
+        )
     }
 
     #[test]
@@ -127,6 +143,9 @@ mod test {
         };
         let project_paths = project_paths(&args);
 
-        assert_eq!(project_paths.project_file, PathBuf::from("/tmp/.muxed/projectname.yml"))
+        assert_eq!(
+            project_paths.project_file,
+            PathBuf::from("/tmp/.muxed/projectname.yml")
+        )
     }
 }

--- a/list/Cargo.toml
+++ b/list/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "list"
+version = "0.8.2-development"
+authors = ["Brian Pearce"]
+publish = false
+
+[lib]
+doctest = false
+
+[dependencies]
+common = { path = "../common" }

--- a/list/src/lib.rs
+++ b/list/src/lib.rs
@@ -1,0 +1,7 @@
+extern crate common;
+
+use common::args::Args;
+
+pub fn exec(_args: Args) -> Result<(), String> {
+    Ok(())
+}

--- a/list/src/lib.rs
+++ b/list/src/lib.rs
@@ -1,7 +1,31 @@
 extern crate common;
 
 use common::args::Args;
+use common::first_run::check_first_run;
+use common::project_paths::project_paths;
 
-pub fn exec(_args: Args) -> Result<(), String> {
+use std::path::PathBuf;
+
+pub fn exec(args: Args) -> Result<(), String> {
+    let project_paths = project_paths(&args);
+    check_first_run(&project_paths.project_directory)?;
+
+    let projects: Vec<String> = project_paths
+        .project_directory
+        .read_dir()
+        .map_err(|_| "Could not read the dir")?
+        .filter_map(|path| path.ok())
+        .map(|path| PathBuf::from(path.file_name()))
+        .filter_map(|buf| match buf.extension().and_then(|x| x.to_str()) {
+            Some("yml") => buf
+                .file_stem()
+                .and_then(|x| x.to_str())
+                .map(|x| x.to_string()),
+            _ => None,
+        })
+        .collect();
+
+    println!("{}", projects.join(" "));
+
     Ok(())
 }

--- a/list/src/lib.rs
+++ b/list/src/lib.rs
@@ -2,7 +2,7 @@ extern crate common;
 
 use common::args::Args;
 use common::first_run::check_first_run;
-use common::project_paths::project_paths;
+use common::project_paths::{project_paths, CONFIG_EXTENSION};
 
 use std::path::PathBuf;
 
@@ -17,7 +17,7 @@ pub fn exec(args: Args) -> Result<(), String> {
         .filter_map(|path| path.ok())
         .map(|path| PathBuf::from(path.file_name()))
         .filter_map(|buf| match buf.extension().and_then(|x| x.to_str()) {
-            Some("yml") => buf
+            Some(CONFIG_EXTENSION) => buf
                 .file_stem()
                 .and_then(|x| x.to_str())
                 .map(|x| x.to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ static DISALLOWED_SHORTHAND_PROJECT_NAMES: [&str; 4] = ["new", "edit", "load", "
 
 static USAGE: &str = "
 Usage:
-    muxed list
+    muxed (list | ls)
     muxed [flags] [options] <project>
     muxed edit [options] <project>
     muxed load [flags] [options] <project>
@@ -100,7 +100,7 @@ pub fn main() {
         try_or_err!(new::exec(args));
     } else if args.cmd_snapshot {
         try_or_err!(snapshot::exec(args));
-    } else if args.cmd_list {
+    } else if args.cmd_list || args.cmd_ls {
         try_or_err!(list::exec(args));
     } else {
         if DISALLOWED_SHORTHAND_PROJECT_NAMES.contains(&args.arg_project.as_ref()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,11 +53,11 @@ Args:
     <project>           The name of your project to open
 
 Subcommands:
+    list                             List the availiable project configs
     edit <project>                   Edit an existing project file
     load <project>                   Load the specified project, this is the default command
     new <project>                    To create a new project file
     snapshot -t <session> <project>  Capture a running session and create a config file for it
-    list                             List the availiable project configs
 ";
 
 /// The main execution method.
@@ -91,8 +91,6 @@ pub fn main() {
         println!("Muxed {}", env!("CARGO_PKG_VERSION"));
         exit(0);
     };
-
-    println!("{:?}", args);
 
     if args.cmd_edit {
         try_or_err!(edit::exec(args));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate common;
 extern crate docopt;
 extern crate edit;
+extern crate list;
 extern crate load;
 extern crate new;
 extern crate snapshot;
@@ -28,6 +29,7 @@ static DISALLOWED_SHORTHAND_PROJECT_NAMES: [&str; 4] = ["new", "edit", "load", "
 
 static USAGE: &str = "
 Usage:
+    muxed list
     muxed [flags] [options] <project>
     muxed edit [options] <project>
     muxed load [flags] [options] <project>
@@ -55,6 +57,7 @@ Subcommands:
     load <project>                   Load the specified project, this is the default command
     new <project>                    To create a new project file
     snapshot -t <session> <project>  Capture a running session and create a config file for it
+    list                             List the availiable project configs
 ";
 
 /// The main execution method.
@@ -89,6 +92,8 @@ pub fn main() {
         exit(0);
     };
 
+    println!("{:?}", args);
+
     if args.cmd_edit {
         try_or_err!(edit::exec(args));
     } else if args.cmd_load {
@@ -97,6 +102,8 @@ pub fn main() {
         try_or_err!(new::exec(args));
     } else if args.cmd_snapshot {
         try_or_err!(snapshot::exec(args));
+    } else if args.cmd_list {
+        try_or_err!(list::exec(args));
     } else {
         if DISALLOWED_SHORTHAND_PROJECT_NAMES.contains(&args.arg_project.as_ref()) {
             println!(


### PR DESCRIPTION
Hello again @brianp!

Been using `muxed` for a bit and really liking it! Occasionally I've wanted to list the projects that I had a muxed config for. I've been just doing `ls ~/.muxed` but thought it might be better to have some sort of first party support.

It also seems like this could be that start to more complicated bash completion, using the actual tool to generate the options!

This is just a rough draft start, it does correctly list the projects but is just a single function right now, and has no tests lol. Thought I'd open this as a draft to get it out, but definitely needs some love prior to merging.
 